### PR TITLE
feat: docker image support multi-platforms(linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,28 +3,25 @@ name: ci
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: pawanosman/chatgpt:latest


### PR DESCRIPTION
[Before](https://discord.com/channels/1055397662976905229/1225778662532579418/1226122691870720020) only support linux/amd64: 

<img width="650" alt="image" src="https://github.com/PawanOsman/ChatGPT/assets/46549482/82082116-f1bc-43fc-96a1-8bf69872da68">
<img width="650" alt="image" src="https://github.com/PawanOsman/ChatGPT/assets/46549482/b1e2c3e7-3219-460f-b1e5-acd4cd20ddb9">

---

Now it support both `linux/amd64` & `linux/arm64` by [adding](https://github.com/changchiyou/ChatGPT-reverseAPI/blob/833a2556128e63835c05e4fdfa191f534cdc103d/.github/workflows/docker-publish.yml#L26):

```
          platforms: linux/amd64,linux/arm64
```
