### PR TITLE
fix: 🐛 Heartbeat data skipped every 15

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -149,6 +149,10 @@ async function handleChatCompletion(req: Request, res: Response) {
 		let created = Date.now();
 
 		for await (const message of StreamCompletion(response.data)) {
+
+			// Skip heartbeat detection
+			if (message.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}$/)) continue;
+			
 			const parsed = JSON.parse(message);
 
 			let content = parsed?.message?.content?.parts[0] ?? "";


### PR DESCRIPTION
I used to find a long reply often will be interrupted, after testing because openai every 15s will send a heartbeat data, content like this time: `2024-04-07 20:20:50.554328`, it will lead to `JSON.parse(message);` an exception!

Fix axios library does not support http2 heartbeat data causing errors, manually skip the time string of heartbeat data