### PR TITLE
Fix response timestamp

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -172,7 +172,7 @@ async function handleChatCompletion(req: Request, res: Response) {
 
 		let fullContent = "";
 		let requestId = GenerateCompletionId("chatcmpl-");
-		let created = Date.now();
+		let created = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
 		let finish_reason = null;
 
 		for await (const message of StreamCompletion(response.data)) {


### PR DESCRIPTION
fix: `created` should be in seconds, https://github.com/openai/openai-openapi/blob/master/openapi.yaml\#L6972