### PR TITLE
Fix: The "file" argument must be of type string. (Cloudflared)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -385,6 +385,11 @@ async function DownloadCloudflared(): Promise<string> {
 }
 
 async function StartCloudflaredTunnel(cloudflaredPath: string): Promise<string> {
+	if (!cloudflaredPath) {
+        console.error("Failed to download Cloudflared executable.");
+        return null;
+    }
+
 	const localUrl = `http://localhost:${port}`;
 	return new Promise<string>((resolve, reject) => {
 		cloudflared = spawn(cloudflaredPath, ["tunnel", "--url", localUrl]);


### PR DESCRIPTION
deals with https://github.com/PawanOsman/ChatGPT/issues/95
so people are atleast able to run it locally, if cloudflared download fails.