### PR TITLE
Add access authentication by api_key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 SERVER_PORT=3040
 USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+NEW_SESSION_RETRIES=5
+API_KEY=
 CLOUDFLARED=true
 
 PROXY=false


### PR DESCRIPTION
follow [#98]
Set API_KEY="xxxx" in .env to enable client authentication
Only clients using the specified api_key can request the api normally
Setting API_KEY to empty disables authentication and allows any client to access. 