### PR TITLE
Include cloudflared.exe in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 db.json
 .env
 cloudflared
+cloudflared.exe


### PR DESCRIPTION
Self-explanatory - windows creates a cloudflared.exe, not just cloudflared (what linux makes?)